### PR TITLE
SeaMonkey Support

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -4,3 +4,4 @@ locale    sabnzbdfox   en-US         chrome/locale/en-US/
 resource  sabnzbdfox                 modules/
 
 overlay   chrome://browser/content/browser.xul   chrome://sabnzbdfox/content/ff-overlay.xul
+overlay   chrome://navigator/content/navigator.xul   chrome://sabnzbdfox/content/ff-overlay.xul

--- a/install.rdf
+++ b/install.rdf
@@ -11,12 +11,19 @@
     
     <em:creator>Alexandre Poirot; http://www.techno-barje.fr/</em:creator>
     
-     <!-- Firefox -->
     <em:targetApplication>
+		<!-- Firefox -->
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>3.5</em:minVersion>
         <em:maxVersion>14.*</em:maxVersion>
+      </Description>
+	  <!-- SeaMonkey -->
+      <Description>
+        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id> <!-- SeaMonkey -->
+        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+        <em:minVersion>2.0</em:minVersion>
+        <em:maxVersion>2.*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>

--- a/install.rdf
+++ b/install.rdf
@@ -20,7 +20,6 @@
       </Description>
 	  <!-- SeaMonkey -->
       <Description>
-        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id> <!-- SeaMonkey -->
         <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
         <em:minVersion>2.0</em:minVersion>
         <em:maxVersion>2.*</em:maxVersion>


### PR DESCRIPTION
Added in code to the chrome.manifest and install.rdf so that the extension can be installed in SeaMonkey.
No other code changes are required.
